### PR TITLE
Adapted LMCache Test to new version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ It's recommended to create a new folder before cloning the repository. The final
 
 ```
 <parent-folder>/
-©À©¤©¤ lmcache-test/
-©À©¤©¤ LMCache/
-©¸©¤©¤ lmcache-vllm/
+|--- lmcache-test/
+|--- LMCache/
+|--- lmcache-vllm/
 ```
 
 ## 1. Environment installation

--- a/README.md
+++ b/README.md
@@ -1,15 +1,29 @@
 # End-to-end test for LMCache
 
-Note: currently, this doc is for onboarding the new developers. Will have a separate README in the future for general audiences.
+> Note: currently, this doc is for onboarding the new developers. Will have a separate README in the future for general audiences.
+
+It's recommended to create a new folder before cloning the repository. The final file structure will look like as follows:
+
+```
+<parent-folder>/
+©À©¤©¤ lmcache-test/
+©À©¤©¤ LMCache/
+©¸©¤©¤ lmcache-vllm/
+```
 
 ## 1. Environment installation
+
 
 ```bash
 # Create conda environment
 conda create -n lmcache python=3.10
 conda activate lmcache
 
-# run the installation script
+# Clone github repository
+git clone git@github.com:LMCache/lmcache-tests.git
+cd lmcache-tests
+
+# Run the installation script
 bash prepare_environment.sh
 ```
 
@@ -20,7 +34,7 @@ bash prepare_environment.sh
 The following command line runs the test `test_lmcache_local_cpu` defined in `tests/tests.py` and write the output results to the output folder (`outputs/test_lmcache_local_cpu.csv`).
 
 ```bash
-python3 main.py tests/test.py -f test_lmcache_local_cpu -o outputs/
+python3 main.py tests/tests.py -f test_lmcache_local_cpu -o outputs/
 ```
 
 To process the result, please run

--- a/configs.py
+++ b/configs.py
@@ -54,15 +54,16 @@ class LMCacheConfig(Config):
     remote_device: Optional[str] = None
 
     def cmdargs(self) -> str:
-        return f"--lmcache-config-file {self.config_path}" if self.config_path is not None else ""
+        return " " if self.config_path is not None else ""
+        # return f"--lmcache-config-file {self.config_path}" if self.config_path is not None else ""
 
 @dataclass
 class VLLMConfig(Config):
-    # vLLM engine's port 
-    port: int
-
     # which Model is used
     model: str
+
+    # vLLM engine's port 
+    port: int
 
     # Memory limit for the vLLM engine
     gpu_memory_utilization: float
@@ -74,6 +75,9 @@ class VLLMConfig(Config):
         args = []
         for key, value in self.__dict__.items():
             if value is None:
+                continue
+            if key=="model":
+                args.append(f"{value}")
                 continue
             modified_key = key.replace("_", "-")
             args.append(f"--{modified_key} {value}")

--- a/configs/lmcache_local_cpu old.yaml
+++ b/configs/lmcache_local_cpu old.yaml
@@ -1,7 +1,0 @@
-chunk_size: 256
-local_device: "cpu"
-remote_url: null
-remote_serde: "cachegen"
-
-# Whether retrieve() is pipelined or not
-pipelined_backend: False

--- a/configs/lmcache_local_cpu old.yaml
+++ b/configs/lmcache_local_cpu old.yaml
@@ -1,5 +1,7 @@
 chunk_size: 256
 local_device: "cpu"
+remote_url: null
+remote_serde: "cachegen"
 
 # Whether retrieve() is pipelined or not
 pipelined_backend: False

--- a/prepare_environment.sh
+++ b/prepare_environment.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+pip install matplotlib
+
+
 # Check conda
 if [[ -z $CONDA_DEFAULT_ENV || $CONDA_DEFAULT_ENV == "base" ]]; then
     echo -e "\033[31mPlease activate a conda environment before running this script.\033[0m"
@@ -10,40 +13,32 @@ fi
 
 # Check python version matches 3.10
 python_version=$(python3 -c "import sys; print(sys.version_info[:2])")
-if [ "$python_version" != "(3, 10)" ]; then
-    echo -e "\033[31mPlease use Python 3 to run this script.\033[0m"
+if [[ ! "$python_version" =~ ^\(3,\ 1[0-9]\) ]]; then
+    echo -e "\033[31mPlease use Python >= 3.10 to run this script.\033[0m"
     exit 1
 fi
 
 # Step 1: clone the code
-git clone https://github.com/LMCache/lmcache-vllm.git ../lmcache-vllm
-git clone https://github.com/LMCache/lmcache-server.git ../lmcache-server
+pip install vllm==0.6.1.post2
 git clone https://github.com/LMCache/LMCache.git ../LMCache
-git clone --branch dev/lmcache-integration https://github.com/LMCache/vllm.git ../vllm
+git clone https://github.com/LMCache/lmcache-vllm.git ../lmcache-vllm
 
-# Step 2: install vllm
-cd ../vllm
-pip install -e .
-pip install numpy==1.26.1 # FIXME: this is a temporary fix for the numpy version
-output=$(python3 -c "import vllm; print(vllm.__name__)") # Check the installation
+# Step 2: Check vllm installation
+output=$(python3 -c "import vllm; print(vllm.__name__)")
 if [ "$output" != "vllm" ]; then
     echo -e "\033[31mvLLM is not installed successfully.\033[0m"
     exit 1
 fi
 echo -e "\033[32mvLLM is installed successfully.\033[0m"
 
-# Step 3: install LMCache and its dependencies
+# Step 3: install LMCache and CUDA
 cd ../LMCache
-cd third_party/torchac_cuda
 pip install -e .
 output=$(python3 -c "import torch; import torchac_cuda; print(torchac_cuda.__name__)")
 if [ "$output" != "torchac_cuda" ]; then
     echo -e "\033[31mtorchac_cuda is not installed successfully.\033[0m"
     exit 1
 fi
-
-cd ../..
-pip install -e .
 output=$(python3 -c "import lmcache; print(lmcache.__name__)")
 if [ "$output" != "lmcache" ]; then
     echo -e "\033[31mLMCache is not installed successfully.\033[0m"
@@ -53,18 +48,17 @@ fi
 # Step 4: install LMCache vllm driver
 cd ../lmcache-vllm
 pip install -e .
-pip install nvtx openai
 output=$(python3 -c "import lmcache_vllm; print(lmcache_vllm.__name__)" | grep lmcache_vllm)
 if [ "$output" != "lmcache_vllm" ]; then
     echo -e "\033[31mLMCache vllm driver is not installed successfully.\033[0m"
     exit 1
 fi
 
-# Step 5: install LMCache server
-cd ../lmcache-server
-pip install -e .
-output=$(python3 -c "import lmcache_server; print(lmcache_server.__name__)" | grep lmcache_server)
-if [ "$output" != "lmcache_server" ]; then
+# Step 5: Check LMCache server
+output=$(python3 -c "import lmcache.server; print(lmcache.server.__name__)" | grep lmcache.server)
+if [ "$output" != "lmcache.server" ]; then
     echo -e "\033[31mLMCache server is not installed successfully.\033[0m"
     exit 1
 fi
+
+echo -e "\033[32mLMCache is installed successfully.\033[0m"

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -21,7 +21,7 @@ def CreateSingleLocalBootstrapConfig(
         vllm_config = VLLMConfig(
             port = port,
             model = model,
-            gpu_memory_utilization = 0.5,
+            gpu_memory_utilization = 0.8,
             tensor_parallel_size = 1),
         vllm_optional_config = VLLMOptionalConfig(),
         lmcache_config = LMCacheConfig(lmcache_config_path),
@@ -65,7 +65,8 @@ def test_lmcache_local_cpu() -> pd.DataFrame:
 
     # Experiments: 8K, 16K, 24K shared context, each experiments has 5 queries
     lengths = [8192, 16384, 24576]
-    experiments = [CreateDummyExperiment(10, length) for length in lengths]
+    # lengths = [8192]
+    experiments = [CreateDummyExperiment(10, length ) for length in lengths]
 
     test_case = TestCase(
             experiments = experiments,
@@ -193,7 +194,7 @@ def test_lmcache_safetensor_distributed() -> pd.DataFrame:
 def test_lmcache_remote_disk() -> pd.DataFrame:
     # Start two servers: with lmcache and without lmcache
     config1 = CreateSingleLocalBootstrapConfig(8000, 0, "mistralai/Mistral-7B-Instruct-v0.2", "configs/lmcache_remote_cachegen.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, "mistralai/Mistral-7B-Instruct-v0.2", None)
+    config2 = CreateSingleLocalBootstrapConfig(8002, 1, "mistralai/Mistral-7B-Instruct-v0.2", None)
 
     config1.lmcache_config.remote_device = "/local/lmcache-tests/lmcache-server"
 


### PR DESCRIPTION
Update installation script in the current lmcache-tests repo to new LMCache (install from source)
Update the command line for Local bootstraper to use the latest lmcache_vllm

Python 3.10/3.11/3.12 are all verified。
Tested on `test_lmcache_local_cpu` and `test_lmcache_remote_disk`