### PR TITLE
[Fix] fix multi-turn chat

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -393,17 +393,18 @@ def run_multi_turn_experiment(
         # Execute the requests
         executor = RequestExecutor()
 
-        # Generation and execution in multi turns (hard-coded 5 turns)
+        # Generation and execution in multi turns (hard-coded 10 turns)
         results = []
         gpu_usage = []
-        for i in range(5):
+        for i in range(10):
             workloads = [generator.generate() for generator in workload_generators]
             executor.schedule_requests(workloads, clients, models)
             results.append(executor.execute_all_with_output())
+            [setattr(result, 'request_id', i) for result in results[i]]
             gpu_usage.append(read_gpu_memory())
             for idx, generator in enumerate(workload_generators):
                 generator.offset += 1 / workload_config.qps
-                generator.store(results[i][0].messages)
+                generator.store(results[i][idx].messages)
 
     except Exception as e:
         logger.error(f"Experiment failed: {e}")

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def wrapped_test_runner(test_func, model, output_file):
         output_df.to_csv(output_file, index=False)
         logger.info("Saving output to " + output_file)
     else:
-        logger.warn(f"Output is {type(output_df)}, not a DataFrame. Skipping saving to file.")
+        logger.warning(f"Output is {type(output_df)}, not a DataFrame. Skipping saving to file.")
 
 def main():
     

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ def wrapped_test_runner(test_func, model, output_file):
         output_df.to_csv(output_file, index=False)
         logger.info("Saving output to " + output_file)
     else:
-        logger.warn(f"Output is {type(output)}, not a DataFrame. Skipping saving to file.")
+        logger.warn(f"Output is {type(output_df)}, not a DataFrame. Skipping saving to file.")
 
 def main():
     

--- a/outputs/process_result.py
+++ b/outputs/process_result.py
@@ -29,7 +29,9 @@ def process_result_file(filename):
     # For TTFT
     for expr_id, g in df.groupby("expr_id"):
         context_len = list(g["context_len"])[0]
-        fig, ax = plot_df(g, x = "request_id", y = "TTFT", group="engine_id", kind = "line", ylabel="TTFT (s)", ylim = (0, None))
+        max_ttft = g["TTFT"].max()  # Get the maximum throughput value
+        ylim_max = max_ttft + 0.5  # Set the upper limit to max value + 0.5
+        fig, ax = plot_df(g, x = "request_id", y = "TTFT", group="engine_id", kind = "line", ylabel="TTFT (s)", ylim = (0, ylim_max))
         ax.set_title(f"Context len = {context_len}")
         pdf_pages.savefig(fig, bbox_inches="tight")
 

--- a/tests/offline_test.py
+++ b/tests/offline_test.py
@@ -4,7 +4,9 @@ import os
 import time
 import logging
 import random
+import subprocess
 
+from lmcache_vllm import close_lmcache_engine
 from lmcache_vllm.vllm import LLM, SamplingParams
 from transformers import AutoTokenizer
 
@@ -156,3 +158,7 @@ for i in range(3):
     with open(output_file, "a") as f:
         f.write(f"\n\nBatched request:\n\n")
     append_outputs(output_file, third_outputs, context_length+context_length_random, t6 - t5)
+
+# Graceful exit
+close_lmcache_engine()
+subprocess.run("lsof -i:65431 -t | xargs kill -9", shell=True)

--- a/tests/offline_test.py
+++ b/tests/offline_test.py
@@ -82,7 +82,7 @@ def append_outputs(output_file_name, outputs, context_length, time_taken):
         f.write(json.dumps(json_dict) + '\n')
 
 # Create a sampling params object.
-sampling_params = SamplingParams(temperature=1, max_tokens=1) # Set to 1 for TTFT
+sampling_params = SamplingParams(temperature=0, max_tokens=1) # Set to 1 for TTFT
 # Create an LLM.
 llm = LLM(model=model_name,
           gpu_memory_utilization=0.6,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -68,8 +68,9 @@ def ModelConfig(model: str, BootstrapConfig) -> None:
             pass
         case "THUDM/glm-4-9b-chat":
             BootstrapConfig.vllm_config.tensor_parallel_size = 2
-            BootstrapConfig.vllm_config.gpu_memory_utilization = 0.8
             BootstrapConfig.vllm_optional_config["trust_remote_code"] = ""
+            BootstrapConfig.vllm_optional_config["enable_chunked_prefill"] = False
+            BootstrapConfig.vllm_optional_config["max_model_len"] = get_max_context_length(model)
         case "meta-llama/Llama-3.1-8B-Instruct":
             BootstrapConfig.vllm_optional_config["enable_chunked_prefill"] = False
             BootstrapConfig.vllm_optional_config["max_model_len"] = get_max_context_length(model)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -79,6 +79,9 @@ def ModelConfig(model: str, BootstrapConfig) -> None:
 
 ##### Test cases #####
 def offline_test(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+    """
+    This function tests partial prefll and full prefill in a single batch.
+    """
     user_name=os.popen('whoami').read()[:-1]
     stdout_log = os.path.join(f"/tmp/{user_name}-65431-stdout.log")
     stderr_log = os.path.join(f"/tmp/{user_name}-65431-stderr.log")
@@ -178,7 +181,7 @@ def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFram
     ModelConfig(model, config)
 
     # Experiment: ONE query that contains 5 rounds 
-    lengths = [16]
+    lengths = [16] # useless for this test case
     experiments = [CreateMultiTurnExperiment(1, length ) for length in lengths]
 
     test_case = TestCase(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -172,12 +172,12 @@ def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFram
     by comparing performance with and without lmcache.
     """
     # Start one server: with lmcache; for contrast (not saving decode KV Cache), change save_decode_cache to false
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu_multi.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
+    config1 = CreateSingleLocalBootstrapConfig(8000, 1, model, "configs/lmcache_local_cpu_multi.yaml")
+    # config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
-    ModelConfig(model, config2)
+    # ModelConfig(model, config2)
 
     # Experiment: ONE query that contains 10 rounds 
     lengths = [16] # useless for this test case
@@ -185,7 +185,8 @@ def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFram
 
     test_case = TestCase(
             experiments = experiments,
-            engines = [config1, config2])
+            # engines = [config1, config2])
+            engines = [config1])
     
     # Run test case
     final_result = run_test_case(test_case)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -172,13 +172,16 @@ def test_vary_length_workload(model = "mistralai/Mistral-7B-Instruct-v0.2") -> p
 
 def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
     """
-    This function tests the performance of saving decode KV Cache by starting a multi-turn conversation.
+    This function tests the performance of saving decode KV Cache with a multi-turn conversation
+    by comparing performance with and without lmcache.
     """
     # Start one server: with lmcache; for contrast (not saving decode KV Cache), change save_decode_cache to false
-    config = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu_multi.yaml")
+    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu_multi.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(8000, 1, model, None)
 
     # Set vllm configuration for different models
-    ModelConfig(model, config)
+    ModelConfig(model, config1)
+    ModelConfig(model, config2)
 
     # Experiment: ONE query that contains 5 rounds 
     lengths = [16] # useless for this test case
@@ -186,7 +189,7 @@ def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFram
 
     test_case = TestCase(
             experiments = experiments,
-            engines = [config])
+            engines = [config1, config2])
     
     # Run test case
     final_result = run_test_case(test_case)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -85,15 +85,11 @@ def offline_test(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
     user_name=os.popen('whoami').read()[:-1]
     stdout_log = os.path.join(f"/tmp/{user_name}-65431-stdout.log")
     stderr_log = os.path.join(f"/tmp/{user_name}-65431-stderr.log")
-    stdout_log2 = os.path.join(f"/tmp/{user_name}-65431-stdout-1.log")
-    stderr_log2 = os.path.join(f"/tmp/{user_name}-65431-stderr-2.log")
-    pattern = "Server started at"
-    run_command("lmcache_server localhost 65431", stdout_log, stderr_log, detach=True)
+    run_command("lmcache_server localhost 65431", stdout_log, None, detach=True)
     time.sleep(10)
-    # os.environ['LMCACHE_CONFIG_FILE'] = "/local/shaotingf/lmcache1/lmcache-tests/configs/example.yaml"
     os.environ['LMCACHE_CONFIG_FILE'] = "./configs/example.yaml"
-    os.environ['CUDA_VISIBLE_DEVICES'] = '0'
-    run_command("python3 tests/offline_test.py", stdout_log2, stderr_log2, detach=False)
+    os.environ['CUDA_VISIBLE_DEVICES'] = '1'
+    run_command("python3 tests/offline_test.py", None, stderr_log, detach=False)
     return None
 
 def test_cache_compatibility(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
@@ -177,13 +173,13 @@ def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFram
     """
     # Start one server: with lmcache; for contrast (not saving decode KV Cache), change save_decode_cache to false
     config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu_multi.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8000, 1, model, None)
+    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
     ModelConfig(model, config2)
 
-    # Experiment: ONE query that contains 5 rounds 
+    # Experiment: ONE query that contains 10 rounds 
     lengths = [16] # useless for this test case
     experiments = [CreateMultiTurnExperiment(1, length ) for length in lengths]
 

--- a/workload.py
+++ b/workload.py
@@ -113,20 +113,21 @@ class MultiTurnWorkloadGenerator(WorkloadGenerator):
         super().__init__(config)
         self.dummy_context = "This is some dummy text. "
         self.estimated_num_tokens_context = utils.estimate_num_tokens(self.dummy_context)
-        dummy_question = "Index 0. Question: Please write a very long essay about whatever topic. "
+        dummy_question = "Index x.  Question: Please write a very long essay about whatever topic. "
         self.estimated_num_tokens_question = utils.estimate_num_tokens(dummy_question)
         self.memory = ""
         self.offset = self.config.offset
+        self.separator = "<<splitter>>"
 
     def generate_context(self) -> str:
-        return self.memory + self.dummy_context * (self.config.context_length // self.estimated_num_tokens_context)
+        return self.memory
 
     def generate_question(self, index: int) -> str:
         if self.config.query_length - self.estimated_num_tokens_question > 0:
             question_prefix = self.dummy_context * ((self.config.query_length - self.estimated_num_tokens_question) // self.estimated_num_tokens_context)
         else:
             question_prefix = ""
-        return f"Index {index}. {question_prefix} Question: Please write a very long essay about whatever topic. "
+        return f"Index x. {question_prefix} Question: Please write a very long essay about whatever topic. "
 
     def generate(self) -> List[Request]:
         num_requests = int(self.config.duration * self.config.qps)
@@ -143,7 +144,7 @@ class MultiTurnWorkloadGenerator(WorkloadGenerator):
         return ret
     
     def store(self, memory: str) -> None:
-        self.memory = self.memory + memory
+        self.memory = f"{self.memory}{self.separator}{memory}"
 
 #if __name__ == "__main__":
 #    config = WorkloadConfig(


### PR DESCRIPTION
This PR mainly does:
- briefly describe the setup in each test case (by adding some comments)
- fix the bug in multi-turn chat (by modifying message store and sending pattern)
- add graceful exit for offline test (by shut down lmcache_engine and backend in `offline_test.py`)
- add vllm config for "THUDM/glm-4-9b-chat"