### PR TITLE
[Fix] Starting engine script

### DIFF
--- a/driver.py
+++ b/driver.py
@@ -307,9 +307,10 @@ def run_experiment(
 
 
     # Start the serving engine
-    bootstrappers = [CreateBootstrapper(config) for config in engine_configs]
-    for bootstrapper in bootstrappers:
-        bootstrapper.start()
+    bootstrappers = []
+    for config in engine_configs:
+        bootstrappers.append(CreateBootstrapper(config))
+        bootstrappers[-1].start()
 
     try:
         # Wait for the engines to be ready
@@ -373,9 +374,10 @@ def run_multi_turn_experiment(
     workload_generators = [MultiTurnWorkloadGenerator(workload_config) for _ in engine_configs]
 
     # Start the serving engine
-    bootstrappers = [CreateBootstrapper(config) for config in engine_configs]
-    for bootstrapper in bootstrappers:
-        bootstrapper.start()
+    bootstrappers = []
+    for config in engine_configs:
+        bootstrappers.append(CreateBootstrapper(config))
+        bootstrappers[-1].start()
 
     try:
         # Wait for the engines to be ready
@@ -402,9 +404,9 @@ def run_multi_turn_experiment(
             results.append(executor.execute_all_with_output())
             [setattr(result, 'request_id', i) for result in results[i]]
             gpu_usage.append(read_gpu_memory())
-            for idx, generator in enumerate(workload_generators):
-                generator.offset += 1 / workload_config.qps
-                generator.store(results[i][idx].messages)
+            for result in results[i]:
+                workload_generators[result.engine_id].offset += 1 / workload_config.qps
+                workload_generators[result.engine_id].store(result.messages)
 
     except Exception as e:
         logger.error(f"Experiment failed: {e}")

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -173,12 +173,12 @@ def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFram
     by comparing performance with and without lmcache.
     """
     # Start one server: with lmcache; for contrast (not saving decode KV Cache), change save_decode_cache to false
-    config1 = CreateSingleLocalBootstrapConfig(8000, 1, model, "configs/lmcache_local_cpu_multi.yaml")
-    # config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
+    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, "configs/lmcache_local_cpu_multi.yaml")
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
-    # ModelConfig(model, config2)
+    ModelConfig(model, config2)
 
     # Experiment: ONE query that contains 10 rounds 
     lengths = [16] # useless for this test case
@@ -186,8 +186,7 @@ def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFram
 
     test_case = TestCase(
             experiments = experiments,
-            # engines = [config1, config2])
-            engines = [config1])
+            engines = [config1, config2])
     
     # Run test case
     final_result = run_test_case(test_case)
@@ -400,7 +399,7 @@ def test_lmcache_remote_disk(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd
     config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_remote_cachegen.yaml")
     config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
 
-    config1.lmcache_config.remote_device = "/local/lmcache-tests/lmcache-server"
+    config1.lmcache_config.remote_device = "/local/end-to-end-tests/lmcache-server"
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)

--- a/workload.py
+++ b/workload.py
@@ -113,7 +113,7 @@ class MultiTurnWorkloadGenerator(WorkloadGenerator):
         super().__init__(config)
         self.dummy_context = "This is some dummy text. "
         self.estimated_num_tokens_context = utils.estimate_num_tokens(self.dummy_context)
-        dummy_question = "Index x.  Question: Please write a very long essay about whatever topic. "
+        dummy_question = "Index x.  Question: Please write a very long essay (more than 1500 tokens). "
         self.estimated_num_tokens_question = utils.estimate_num_tokens(dummy_question)
         self.memory = ""
         self.offset = self.config.offset
@@ -127,7 +127,7 @@ class MultiTurnWorkloadGenerator(WorkloadGenerator):
             question_prefix = self.dummy_context * ((self.config.query_length - self.estimated_num_tokens_question) // self.estimated_num_tokens_context)
         else:
             question_prefix = ""
-        return f"Index x. {question_prefix} Question: Please write a very long essay about whatever topic. "
+        return f"Index x. {question_prefix} Question: Please write a very long essay (more than 1500 tokens). "
 
     def generate(self) -> List[Request]:
         num_requests = int(self.config.duration * self.config.qps)


### PR DESCRIPTION
1. Fix the starting engine script. Avoid OS variable LMCACHE_CONFIG_FILE conflict.
2. Add comparison group for multi-turn experiment.