### PR TITLE
supports port config for the tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ There are various test functions available that can be specified using -f / --fi
   * `test_chunk_prefill`: tests the performance of chunked prefill.
   * `test_cache_compatibility`: tests the compatibility of prefix caching between lmcache and vllm.
   * `test_lmcache_local_distributed`: tests the performance of tensor parallelism.
+  * `test_experimental`: tests the codes in `LMCache/lmcache/experimental/`.
 * Remote cpu storage backend
   * `test_lmcache_remote_cachegen`: compares scenarios whether retrieval is pipelined or not with cachegen for transmission.
   * `test_lmcache_cachegen_distributed`: tests the performance of tensor parallelism with cachegen for transmission.

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ There are various test functions available that can be specified using -f / --fi
   * `test_chunk_prefill`: tests the performance of chunked prefill.
   * `test_cache_compatibility`: tests the compatibility of prefix caching between lmcache and vllm.
   * `test_lmcache_local_distributed`: tests the performance of tensor parallelism.
-  * `test_lmcache_local_cpu_experimental`: tests the codes in `LMCache/lmcache/experimental/`.
+  * `test_local_cpu_experimental`: tests the codes in `LMCache/lmcache/experimental/`.
 * Remote cpu storage backend
   * `test_lmcache_remote_cachegen`: compares scenarios whether retrieval is pipelined or not with cachegen for transmission.
   * `test_lmcache_cachegen_distributed`: tests the performance of tensor parallelism with cachegen for transmission.
@@ -129,7 +129,7 @@ There are various test functions available that can be specified using -f / --fi
 * Other storage backend
   * `test_lmcache_local_gpu`: local gpu storage backend.
   * `test_lmcache_local_disk`: local disk storage backend.
-  * `test_lmcache_local_disk_experimental`: tests the codes in `LMCache/lmcache/experimental/` with local disk storage backend.
+  * `test_local_disk_experimental`: tests the codes in `LMCache/lmcache/experimental/` with local disk storage backend.
   * `test_lmcache_remote_disk`: remote disk storage backend.
   * `test_lmcache_redis_sentinel`: Redis instance storage backend. 
 * Offline tests

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ There are various test functions available that can be specified using -f / --fi
   * `test_chunk_prefill`: tests the performance of chunked prefill.
   * `test_cache_compatibility`: tests the compatibility of prefix caching between lmcache and vllm.
   * `test_lmcache_local_distributed`: tests the performance of tensor parallelism.
-  * `test_experimental`: tests the codes in `LMCache/lmcache/experimental/`.
+  * `test_lmcache_local_cpu_experimental`: tests the codes in `LMCache/lmcache/experimental/`.
 * Remote cpu storage backend
   * `test_lmcache_remote_cachegen`: compares scenarios whether retrieval is pipelined or not with cachegen for transmission.
   * `test_lmcache_cachegen_distributed`: tests the performance of tensor parallelism with cachegen for transmission.
@@ -129,6 +129,7 @@ There are various test functions available that can be specified using -f / --fi
 * Other storage backend
   * `test_lmcache_local_gpu`: local gpu storage backend.
   * `test_lmcache_local_disk`: local disk storage backend.
+  * `test_lmcache_local_disk_experimental`: tests the codes in `LMCache/lmcache/experimental/` with local disk storage backend.
   * `test_lmcache_remote_disk`: remote disk storage backend.
   * `test_lmcache_redis_sentinel`: Redis instance storage backend. 
 * Offline tests

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ You can also monitor the following files to check the status of the bootstrapped
 
 For stderr:
 ```bash
-tail -f /tmp/8000-stderr.log
+tail -f /tmp/{user_name}-8000-stderr.log
 ```
 
 For stdout:
 ```bash
-tail -f /tmp/8000-stdout.log
+tail -f /tmp/{user_name}-8000-stdout.log
 ```
 
 
@@ -61,22 +61,20 @@ tail -f /tmp/8000-stdout.log
 
 `main.py` is the entrypoint to execute the test functions:
 ```
-usage: main.py [-h] [-f FILTER] [-l] [-o OUTPUT_DIR] [-m MODEL] filepath
+usage: main.py [-h] [-f FILTER] [-l] [-o OUTPUT_DIR] [-m MODEL] [-p PORT1 PORT2] filepath
 
 Execute all functions in a given Python file.
 
 positional arguments:
-  filepath              The Python file to execute functions from (include subfolders if any).
+  filepath                                  The Python file to execute functions from (include subfolders if any).
 
 options:
-  -h, --help            show this help message and exit
-  -f FILTER, --filter FILTER
-                        Pattern to filter which functions to execute.
-  -l, --list            List all functions in the module without executing them.
-  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
-                        The directory to put the output file.
-  -m MODEL, --model MODEL           
-                        The models of vllm for every functions.
+  -h, --help                                show this help message and exit
+  -f FILTER, --filter FILTER                Pattern to filter which functions to execute.
+  -l, --list                                List all functions in the module without executing them.
+  -o OUTPUT_DIR, --output-dir OUTPUT_DIR    The directory to put the output file.
+  -m MODEL, --model MODEL                   The models of vllm for every functions.
+  -p PORT1 PORT2, --ports PORT1 PORT2       Two ports required for the experiment.
 ```
 
 Here are some examples:
@@ -105,16 +103,39 @@ There should be multiple columns in the CSV:
 - `request_id`: the id of the request in the workload
 - `TTFT`: the time-to-first-token of this request
 - `throughput`: the number of output tokens per second of this request
+- `latency`: the time the whole response completes
 - `context_len`: the context length of this request
 - `query_len`: the query length of this request
 - `gpu_memory`: the gpu memory used before this experiment is finished
 
 Some example codes of how to parse the output CSV can be found in `outputs/process_result.py`.
 
+## 3. An explanation of the current tests
+There are various test functions available that can be specified using -f / --filter. These functions serve the following purposes:
 
-## 3. Contributing guide: understanding the code
+* Local cpu storage backend
+  * `test_lmcache_local_cpu`: compares scenarios with and without lmcache.
+  * `test_multi_turn`: tests the performance of saving decode KV Cache with a multi-turn conversation.
+  * `test_vary_length_workload`: tests the performance of partial prefill by changing the workload length of different requests.
+  * `test_chunk_prefill`: tests the performance of chunked prefill.
+  * `test_cache_compatibility`: tests the compatibility of prefix caching between lmcache and vllm.
+  * `test_lmcache_local_distributed`: tests the performance of tensor parallelism.
+* Remote cpu storage backend
+  * `test_lmcache_remote_cachegen`: compares scenarios whether retrieval is pipelined or not with cachegen for transmission.
+  * `test_lmcache_cachegen_distributed`: tests the performance of tensor parallelism with cachegen for transmission.
+  * `test_lmcache_remote_safetensor`: compares scenarios whether retrieval is pipelined or not with safetensor for transmission.
+  * `test_lmcache_safetensor_distributed`: tests the performance of tensor parallelism with safetensor for transmission.
+* Other storage backend
+  * `test_lmcache_local_gpu`: local gpu storage backend.
+  * `test_lmcache_local_disk`: local disk storage backend.
+  * `test_lmcache_remote_disk`: remote disk storage backend.
+  * `test_lmcache_redis_sentinel`: Redis instance storage backend. 
+* Offline tests
+  * `offline_test`: tests partial prefll and full prefill in a single batch.
 
-### 3.1 Basic terminology
+## 4. Contributing guide: understanding the code
+
+### 4.1 Basic terminology
 
 - **`Request`**: A request is a single prompt containing some context and a user query.
 - **`Engine`**: Means "serving engine". An engine is an LLM serving engine process that can process requests through the OpenAI API interface.
@@ -123,7 +144,7 @@ Some example codes of how to parse the output CSV can be found in `outputs/proce
 - **`Test case`**: A test case contains a list of experiments. The goal is to compare the performance of different engines under different workloads. 
 - **`Test function`**: A test function wraps the test cases and saves the output CSV. In most cases, a single test function only contains one test case. Different test functions aim to test different functionalities of the system.
 
-### 3.2 Main components
+### 4.2 Main components
 
 **Test case configuration**:
 
@@ -171,6 +192,6 @@ The experiment runner takes in _one_ workload config and $N$ engine configs as i
 
 The code can be found in [driver.py](https://github.com/LMCache/lmcache-tests/blob/main/driver.py)
 
-## 4. Contributing guide: adding new tests
+## 5. Contributing guide: adding new tests
 
 (WIP)

--- a/configs/experimental.yaml
+++ b/configs/experimental.yaml
@@ -1,0 +1,4 @@
+chunk_size: 256
+local_cpu: True
+max_local_cpu_size: 5
+

--- a/configs/lmcache_local_disk_exp.yaml
+++ b/configs/lmcache_local_disk_exp.yaml
@@ -1,0 +1,3 @@
+chunk_size: 256
+local_disk: "file:///local/end-to-end-tests/local/"
+max_local_disk_size: 5

--- a/driver.py
+++ b/driver.py
@@ -217,7 +217,7 @@ def execute_openai_request(request: Request, model: str, client: openai.Client) 
         logger.debug(f"Response: {''.join(messages)}")
     except Exception as e:
         logger.error(f"OpenAI request failed: {e}")
-        return -1, -1
+        return -1, -1, -1
 
     return ttft, throughput, latency
 
@@ -273,7 +273,7 @@ def execute_openai_request_with_output(request: Request, model: str, client: ope
         logger.debug(f"Response: {''.join(messages)}")
     except Exception as e:
         logger.error(f"OpenAI request failed: {e}")
-        return -1, -1
+        return -1, -1, ""
 
     return ttft, throughput, f"{''.join(messages)}"
 

--- a/driver.py
+++ b/driver.py
@@ -167,6 +167,19 @@ def create_openai_client(port: int, model) -> openai.Client:
         max_tokens = 1,
     )
 
+    messages = [{
+        "role": "user",
+        "content": f"This is a warm up request" * 201
+        }]
+
+    chat_completion = client.chat.completions.create(
+        messages = messages,
+        model = model,
+        temperature = 0,
+        stream = False,
+        max_tokens = 1,
+    )
+
     return client
 
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -241,7 +241,7 @@ def test_lmcache_local_cpu(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 =
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_local_cpu_experimental(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
+def test_local_cpu_experimental(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function tests the experimental codes in LMCache.
     Expected behavior: reduces GPU memory overhead.
@@ -300,7 +300,7 @@ def test_lmcache_local_disk(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 
 
     return final_result
 
-def test_lmcache_local_disk_experimental(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame: 
+def test_local_disk_experimental(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame: 
     """
     This function tests local disk storage backend by comparing scenarios with and without lmcache.
     """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -295,6 +295,7 @@ def test_lmcache_local_disk(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 
     with open(yaml_config, 'r') as file:
         data = yaml.safe_load(file)
     local_device = data.get('local_device') + "*"
+    local_device = local_device.replace("file://", "")
     os.system(f"rm -rf {local_device}")
 
     return final_result

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -94,14 +94,14 @@ def offline_test(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
     run_command("python3 tests/offline_test.py", None, stderr_log, detach=False)
     return None
 
-def test_cache_compatibility(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_cache_compatibility(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function tests the compatibility of prefix caching between lmcache and vllm 
     by comparing performance across enabling prefix caching or not.
     """
     # Start two servers with lmcache enabling prefix caching
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, "configs/lmcache_local_cpu.yaml")
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_local_cpu.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, "configs/lmcache_local_cpu.yaml")
     config1.vllm_optional_config["enable_prefix_caching"] = ""
 
     # Set vllm configuration for different models
@@ -120,13 +120,13 @@ def test_cache_compatibility(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd
     final_result = run_test_case(test_case)
     return final_result
 
-def test_chunk_prefill(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_chunk_prefill(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function tests the performance of chunked prefill by comparing scenarios with and without lmcache.
     """
     # Start two servers: with lmcache and without lmcache
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_local_cpu.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, None)
     config1.vllm_optional_config["enable_chunked_prefill"] = True
     config2.vllm_optional_config["enable_chunked_prefill"] = True
 
@@ -146,12 +146,12 @@ def test_chunk_prefill(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataF
     final_result = run_test_case(test_case)
     return final_result
 
-def test_vary_length_workload(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_vary_length_workload(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function tests the performance of partial prefill by changing the workload length of different requests.
     """
     # Start one server with lmcache
-    config = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu.yaml")
+    config = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_local_cpu.yaml")
 
     # Set vllm configuration for different models
     ModelConfig(model, config)
@@ -168,14 +168,14 @@ def test_vary_length_workload(model = "mistralai/Mistral-7B-Instruct-v0.2") -> p
     final_result = run_test_case(test_case)
     return final_result
 
-def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function tests the performance of saving decode KV Cache with a multi-turn conversation
     by comparing performance with and without lmcache.
     """
     # Start one server: with lmcache; for contrast (not saving decode KV Cache), change save_decode_cache to false
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, "configs/lmcache_local_cpu_multi.yaml")
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_local_cpu.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, "configs/lmcache_local_cpu_multi.yaml")
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
@@ -193,13 +193,13 @@ def test_multi_turn(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFram
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_local_gpu(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_lmcache_local_gpu(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function tests local gpu storage backend by comparing scenarios with and without lmcache.
     """
     # Start two servers: with lmcache and without lmcache
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_gpu.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_local_gpu.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, None)
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
@@ -217,13 +217,13 @@ def test_lmcache_local_gpu(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.D
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_local_cpu(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_lmcache_local_cpu(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function tests local cpu storage backend by comparing scenarios with and without lmcache.
     """
     # Start two servers: with lmcache and without lmcache
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_local_cpu.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, None)
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
@@ -241,14 +241,14 @@ def test_lmcache_local_cpu(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.D
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_local_disk(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame: 
+def test_lmcache_local_disk(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame: 
     """
     This function tests local disk storage backend by comparing scenarios with and without lmcache.
     """
     # Start two servers: with lmcache and without lmcache
     yaml_config = "configs/lmcache_local_disk.yaml"
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, yaml_config)
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, yaml_config)
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, None)
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
@@ -273,11 +273,11 @@ def test_lmcache_local_disk(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.
 
     return final_result
 
-def test_lmcache_local_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame: 
+def test_lmcache_local_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame: 
     """
     Local CPU + TP = 2
     """
-    config = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_local_cpu.yaml")
+    config = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_local_cpu.yaml")
 
     config.vllm_config.tensor_parallel_size = 2
     config.vllm_config.gpu_memory_utilization = 0.6
@@ -298,14 +298,14 @@ def test_lmcache_local_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2")
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_remote_cachegen(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_lmcache_remote_cachegen(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function is set with local cpu storage backend and cachegen for transmission 
     by comparing scenarios whether retrieval is pipelined or not.
     """
     # Start two servers
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_remote_cachegen.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, "configs/lmcache_remote_cachegen_pipeline.yaml")
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_remote_cachegen.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, "configs/lmcache_remote_cachegen_pipeline.yaml")
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
@@ -323,12 +323,12 @@ def test_lmcache_remote_cachegen(model = "mistralai/Mistral-7B-Instruct-v0.2") -
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_cachegen_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_lmcache_cachegen_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function is set with local cpu storage backend and cachegen for transmission 
     by enabling distributed cuda.
     """
-    config = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_remote_cachegen.yaml")
+    config = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_remote_cachegen.yaml")
     #config = CreateSingleLocalBootstrapConfig(8000, 0, "facebook/opt-125m", "configs/lmcache_remote_cachegen.yaml")
 
     config.vllm_config.tensor_parallel_size = 2
@@ -350,14 +350,14 @@ def test_lmcache_cachegen_distributed(model = "mistralai/Mistral-7B-Instruct-v0.
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_remote_safetensor(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_lmcache_remote_safetensor(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function is set with local cpu storage backend and safetensor for transmission 
     by comparing scenarios whether retrieval is pipelined or not.
     """
     # Start two servers: with lmcache and without lmcache
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_remote_safetensor.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, "configs/lmcache_remote_safetensor_pipeline.yaml")
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_remote_safetensor.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, "configs/lmcache_remote_safetensor_pipeline.yaml")
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
@@ -375,11 +375,11 @@ def test_lmcache_remote_safetensor(model = "mistralai/Mistral-7B-Instruct-v0.2")
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_safetensor_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_lmcache_safetensor_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     LMCache remote safetensor + TP = 2
     """
-    config = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_remote_safetensor.yaml")
+    config = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_remote_safetensor.yaml")
 
     config.vllm_config.tensor_parallel_size = 2
     config.vllm_config.gpu_memory_utilization = 0.6
@@ -400,13 +400,13 @@ def test_lmcache_safetensor_distributed(model = "mistralai/Mistral-7B-Instruct-v
     final_result = run_test_case(test_case)
     return final_result
 
-def test_lmcache_remote_disk(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_lmcache_remote_disk(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
     This function tests remote disk storage backend by comparing scenarios with and without lmcache.
     """
     # Start two servers: with lmcache and without lmcache
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_remote_cachegen.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_remote_cachegen.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, None)
 
     config1.lmcache_config.remote_device = "/local/end-to-end-tests/lmcache-server/"
 
@@ -430,12 +430,12 @@ def test_lmcache_remote_disk(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd
 
     return final_result
 
-def test_lmcache_redis_sentinel(model = "mistralai/Mistral-7B-Instruct-v0.2") -> pd.DataFrame:
+def test_lmcache_redis_sentinel(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     # Set up the master node
     os.environ["REDIS_SERVICE_NAME"] = "redismaster"
 
-    config1 = CreateSingleLocalBootstrapConfig(8000, 0, model, "configs/lmcache_redis_sentinel_cachegen.yaml")
-    config2 = CreateSingleLocalBootstrapConfig(8001, 1, model, None)
+    config1 = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_redis_sentinel_cachegen.yaml")
+    config2 = CreateSingleLocalBootstrapConfig(port2, 1, model, None)
 
     # Set vllm configuration for different models
     ModelConfig(model, config1)
@@ -453,7 +453,7 @@ def test_lmcache_redis_sentinel(model = "mistralai/Mistral-7B-Instruct-v0.2") ->
     final_result = run_test_case(test_case)
     return final_result
 
-def dumb_test() -> None:
+def dumb_test(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> None:
     print("This is a dumb_test") 
 
 if __name__ == "__main__":

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -328,7 +328,7 @@ def test_lmcache_local_disk_experimental(model = "mistralai/Mistral-7B-Instruct-
     # Clean up
     with open(yaml_config, 'r') as file:
         data = yaml.safe_load(file)
-    local_device = data.get('local_device') + "*"
+    local_device = data.get('local_disk') + "*"
     local_device = local_device.replace("file://", "")
     os.system(f"rm -rf {local_device}")
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -300,7 +300,7 @@ def test_lmcache_local_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2",
 
 def test_lmcache_remote_cachegen(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
-    This function is set with local cpu storage backend and cachegen for transmission 
+    This function is set with remote cpu storage backend and cachegen for transmission 
     by comparing scenarios whether retrieval is pipelined or not.
     """
     # Start two servers
@@ -325,7 +325,7 @@ def test_lmcache_remote_cachegen(model = "mistralai/Mistral-7B-Instruct-v0.2", p
 
 def test_lmcache_cachegen_distributed(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
-    This function is set with local cpu storage backend and cachegen for transmission 
+    This function is set with remote cpu storage backend and cachegen for transmission 
     by enabling distributed cuda.
     """
     config = CreateSingleLocalBootstrapConfig(port1, 0, model, "configs/lmcache_remote_cachegen.yaml")
@@ -352,7 +352,7 @@ def test_lmcache_cachegen_distributed(model = "mistralai/Mistral-7B-Instruct-v0.
 
 def test_lmcache_remote_safetensor(model = "mistralai/Mistral-7B-Instruct-v0.2", port1 = 8000, port2 = 8001) -> pd.DataFrame:
     """
-    This function is set with local cpu storage backend and safetensor for transmission 
+    This function is set with remote cpu storage backend and safetensor for transmission 
     by comparing scenarios whether retrieval is pipelined or not.
     """
     # Start two servers: with lmcache and without lmcache


### PR DESCRIPTION
1. Support port configuration for all the tests. Avoid hard coded 8000 and 8001.
2. Add explanation of all test functions in Readme.
3. Add E2E test for `experimental` directory in LMCache.
4. Add KV retrieval in warmup request.